### PR TITLE
Cailey/remove namespace/pvc update

### DIFF
--- a/.github/ISSUE_TEMPLATE/github_user_access_request.md
+++ b/.github/ISSUE_TEMPLATE/github_user_access_request.md
@@ -3,7 +3,7 @@ name: Request for BCGOV GitHub Organization Membership
 about: To grant or remove access for a team member to BCGOV GitHub repositories.
 title: ''
 labels: github-membership
-assignees: caggles, ShellyXueHan
+assignees: caggles, ShellyXueHan, mitovskaol
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/openshift_project_request.md
+++ b/.github/ISSUE_TEMPLATE/openshift_project_request.md
@@ -20,6 +20,9 @@ If not, please do so before you submit the request.
 **Have you scaled down all pods to 0 in all 4 project set namespaces - dev, test, tools and prod ?**
 If not, please do so before you submit the request.
 
+**Have you deleted the persistent volume claims in all 4 project set namespaces - dev, test, tools and prod ?**
+If not, please do so before you submit the request.
+
 ## Step 1
 Make sure no duplicated request exists, search here:
 https://github.com/BCDevOps/devops-requests/issues

--- a/.github/ISSUE_TEMPLATE/quota_update.md
+++ b/.github/ISSUE_TEMPLATE/quota_update.md
@@ -3,9 +3,11 @@ name: Request to Change Project Set Quotas
 about: Request changes to cpu/storage/etc
 title: ''
 labels: quota-update, pending
-assignees: caggles, ShellyXueHan, sbarre-esit
+assignees: caggles, ShellyXueHan, 
 
 ---
+
+#**This ticket is for 3.11 requests only.** A new quota request process is being built for OCP4. If you submit a request here for an OCP4 namespace quota change, it will be closed without action.
 
 ## Step 0
 **Are you the product owner or technical lead?**


### PR DESCRIPTION
adds a step that requests the team delete their own PVCs as part of prepping the removal request.