### PR TITLE
Fix broken / outdated links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,18 +1,18 @@
 blank_issues_enabled: false
 contact_links:
   - name: Request user membership to Openshift or BC Gov/BCDevOps orgs, and access to create a public GitHub repo
-    url: https://developer.gov.bc.ca/User-access-into-Github-or-Openshift
-    about: These tasks are now self-serve :) 
+    url: https://just-ask.developer.gov.bc.ca
+    about: These tasks are now self-serve using the "Jus Ask" tool :) 
   - name: OCP4 Project Set Requests, Annotation Updates, and Quota Changes.
     url: https://registry.developer.gov.bc.ca
     about: All of these tasks are now performed in the Project Registry - make sure to update your bookmarks!
   - name: Request access to RocketChat
-    url: https://developer.gov.bc.ca/Steps-to-join-Rocket.Chat
+    url: https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/rocketchat/steps-to-join-rocketchat/
     about: Did you know that most employees and contractors don't need to an invite to join Rocketchat? You can log straight in! More info at the link!
   - name: Request for an Pathfinder SSO Client in a standard realm
     url: https://bcgov.github.io/sso-requests/
     about: To create a set of Pathfinder SSO clients (in KeyCloak DEV, TEST, PROD).
-  - name: Human help needed
-    url: https://developer.gov.bc.ca/Getting-human-support-for-issues-not-covered-by-devops-requests
-    about: The community on RocketChat is always eager to help with your technical questions!
+  - name: Get support
+    url: https://digital.gov.bc.ca/cloud/services/private/support/
+    about: View different support resources and channels.
 


### PR DESCRIPTION
Some links are no longer valid with the latest DevHub redirects and move of some content to Digital.gov. This PR contains changes to repair the links.